### PR TITLE
Update version to v0.15.0

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.14.2
+version:        0.15.0
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language


### PR DESCRIPTION
- Implement `Coercible` for safe zero-cost coercions (#3351)
- Golden tests for `purs/failing` and `purs/warning` (#3774)
- [purs ide] Updates the cache-db.json file on rebuilds (#3789)
- Fix typos (#3795)
- [purs ide] Tracks the cache-db.json timestamp (#3799)
- Split into packages (#3793)
- Add golden tests for Coercible (#3810)
- Polykinds (#3779)
- Fix DuplicateModule.purs golden test (#3811)
- Relax dependency to `microlens` (#3817)
- Remove PackageImports (#3821)
- Run golden tests in CI (#3808)
- Use the same default extensions everywhere (#3823)
- Deprecate primes in identifiers exported from foreign modules (#3792)
- Fix make ghcid (#3826)
- Fix substitution during kind generalization (#3831)
- Binary encoding for externs (#3841)
- Pretty print errors as warnings in warnings golden tests (#3846)
- Fix build with new Happy versions. (#3837)
- [purs ide] Hides compiler internals in Prim modules from completions (#3850)
- Represents ModuleNames as a single Text (#3843)
- Add ES imports/exports to CoreImp AST
- Print ES imports/exports
- Codegen ES imports for PureScript modules
- Codegen ES imports for foreign modules
- Codegen ES exports
- Extract both CJS and ES exports from foreign modules
- Remove the redundant "use strict;" pragma from modules header
- Don’t emit empty statements for empty exports lists
- Bundle ES modules
- Load ES modules with `esm` in the Node.js REPL and tests
- Escape primes in modules accessors
- Forbid unescaped primes in foreign modules exports
- Run tests against patched dependencies
- Rewrite ES modules in the browser REPL client
- Create issue templates (#3853)
- Deprecate constraints in foreign imports (#3829)
- Remove legacy resolutions format (#3847)
- [purs ide] Extracts documentation comments for type classes (#3856)
- Print compile errors to stdout, progress messages to stderr (#3839)
- Setup `hlint` to run in the project (#3816)
- Fix hlint warnings (#3864)
- Remove core tests (#3861)
- Fix CoreFn FromJSON version parsing and add test (#3877)
- Printer for CST Modules (#3887)
- Updated purescript version in package.yaml (#3894)
- Recurse on the right of arrows and under foralls when inferring nominal roles from kinds (#3896)
- Have module re-exports appear in generated code (#3883)
- Check role declarations against inferred roles (#3873)
- Faster warnDuplicateRefs (#3899)
- Pin language-javascript to a specific version (#3904)
- Check roles of mutually recursive types (#3860)
- Updated link to book (#3916)
- Add troubleshooting steps for libtinfo and EACCES errors (#3903)
- Disallow `Coercible` instance declarations (#3905)
- Copy default-extensions.yaml to subprojects (#3908)
- Update CONTRIBUTING.md (#3924)
- Link to releases page (#3920)
- Forbid partial data constructors exports (#3872)
- Saturate higher kinded types in `Coercible` constraints (#3893)
- Remove spurious doc comment on CoreFn Module (#3552)
- Disallow cycles in foreign data kinds (#3929)
- Expand type synonyms before role checking (#3909)
- Fix `Coercible` golden tests (#3931)
- Walk under constrained types during role inference (#3906)
- Check role declarations make sense (#3881)
- Solve `Coercible` constraints on rows (#3878)
- Bump version for 0.14.0-rc2 (#3934)
- Desugar type operator aliases inside parens (#3935)
- Check all recursive paths in data binding groups (#3936)
- Allow instances for synonyms (#3539)
- Require newtype constructors to be imported for coercing them (#3937)
- Turn `Coercible` into a symmetric relation (#3930)
- Warn against exported types with hidden constructors but `Generic` or `Newtype` instances (#3907)
- Update the desugaring pipeline to work on individual modules (#3944)
- Update version to 0.14.0-rc3 (#3945)
- Add source span to PartiallyAppliedSynonym errors (#3951)
- Improve error message when `negate` isn't imported (#3952)
- Unsupport bare negative literals as equational binders (#3956)
- Reform handling of quote characters in raw strings (#3961)
- Expand type synonyms in superclasses (#3966)
- Expand type synonyms in instances dictionaries (#3965)
- Interaction solver for Coercible constraints (#3955)
- Update version to 0.14.0-rc4 (#3969)
- Update license-related error messages (#3970)
- Fix operator qualifier reversal bug (#3971)
- Refactor Ord instances (#3902)
- Don't implement Newtype methods when deriving (#3975)
- Add hint about constructor not being in scope when the unwrapping rule fails (#3927)
- Update version to 0.14.0-rc5 (#3976)
- Generate changelog and add PR template (#3989)
- Only include direct dependencies in output for purs graph (#3993)
- Extend ImportCompletion with declarationType (#3997)
- [purs ide] Improves protocol errors from the ide server (#3998)
- Update the changelog with release notes for the upcoming v0.14 (#3994)
- Don't explain Coercible as a class with compiler-generated instances (#3999)
- Erase elaborated kinds from all errors by default (#4007)
- Don't mention unknowns in unification errors when coercing misaligned rows (#4000)
- Release v0.14.0 🎉 (#4014)
- Make close punctuation printable in errors (#3982)
- Drop "Proposal:" prefix in proposal template (#4026)
- Add white outline stroke to logo.png (#4003)
- Drop hpack, make it easier to use cabal-install (#3933)
- Fix exponential collapsing of BindingGroups (#4006)
- Support TCO for functions with tail-recursive inner functions (#3958)
- Revert "Load ES modules with `esm` in the Node.js REPL and tests"
- Updates for GHC 8.10.4 (#4013)
- Allow Node.js to load .js files in the output directory as ES modules
- Import CommonJS foreign modules through an ES module wrapper
- Don't let tests nor the REPL compile into a node_modules directory
- Bundle re-exports
- Load bundles as CommonJS modules in tests
- Update Node.js version on CI
- Disallow CommonJS exports named `default`
- Disallow CommonJS exports and imports in ES foreign modules
- Deprecate CommonJS foreign modules
- Convert CommonJS foreign modules in tests to ES modules
- Don't optimize away dependencies of named ES exports of declarations
- Remove unused Data.Foldable.foldr import (#4042)
- Upgrade tests Bower dependencies (#4041)
- Add hints to nested constraint errors (#4004)
- Use type annotation hint only when needed (#4025)
- Desugar type operators in top-level kind signatures (#4027)
- Instantiate polymorphic kinds when unwrapping newtypes while solving Coercible constraints (#4040)
- Make stack pedantic by default (#4045)
- Fix row unification with shared unknown in tails (#4048)
- Fix wildly off kind unification positions (#4050)
- Unused warnings (#3819)
- Clarify unused warnings changelog entry (#4052)
- Fix kinded declaration reordering in desugaring (#4047)
- Require rebuild if any codegen targets are outdated (#4053)
- Pedantically rename some variables (#4055)
- Fix printing of hiding imports (#4058)
- Update INSTALL.md (#4059)
- Update LICENSE for v0.14.1 (#4060)
- Fix shift/reduce conflicts (#4063)
- Bump versions for v0.14.1 (#4068)
- Update RELEASE_GUIDE.md for multiple packages (#4061)
- Rearrange CHANGELOG entry for 0.14.1 (#4070)
- Prompt to add to CONTRIBUTORS.md (#4074)
- Drop libtinfo dependency (#4069)
- Fixup docs for libtinfo change (#4075)
- Migrate CI from Travis to GitHub Actions (#4077)
- Remove setup-win.cmd (#4076)
- Switch to hspec exclusively, remove tasty (#4057)
- Avoid compiling tests with diagnostics twice (#4079)
- Do less work in test initialization (#4080)
- Note FreeBSD binary packages in the installation instructions. (#4081)
- Unused var tweaks (#4088)
- Make instance names optional by generating them based on types (#4085)
- Remove unneeded HLint ignore directives
- HLint fix: "Parse error"
- HLint fix: "Unused LANGUAGE pragma"
- HLint fix: "Redundant =="
- HLint fix: "Redundant if"
- HLint fix: "Use notElem"
- HLint fix: "Use String"
- HLint fix: "Use isDigit"
- HLint fix: "Use unless"
- HLint fix: "Use traverse_"
- HLint fix: "Use /="
- HLint fix: "Use $>"
- HLint fix: "Use =<<"
- HLint fix: "Use maybe"
- HLint fix: "Use zipWithM_"
- HLint fix: "Use fromMaybe"
- HLint fix: "Use gets"
- HLint fix: "Use unwords"
- HLint fix: "Use &&"
- HLint fix: "Use ++"
- HLint fix: "Use list literal pattern"
- HLint fix: "Use :"
- HLint fix: "Use ."
- HLint fix: "Use Just"
- HLint fix: "Hoist not"
- HLint fix: "Redundant fmap"
- HLint fix: "Use sortOn"
- HLint fix: "Avoid reverse"
- HLint fix: "Redundant bracket"
- HLint fix: "Redundant $"
- HLint fix: "Move brackets to avoid $"
- HLint fix: "Use <$>"
- HLint fix: "Eta reduce"
- HLint fix: "Use join"
- HLint fix: "Use fmap"
- HLint fix: "Use const"
- HLint fix: "Use lambda-case"
- HLint fix: "Use infix"
- HLint fix: "Use tuple-section"
- HLint fix: "Use camelCase"
- Update changelog
- Export `rebuildModule'` to speed up Try PureScript! slightly (#4095)
- Merge purescript-ast into purescript-cst (#4094)
- Bump versions for v0.14.2 (#4103)
- Fix errors when generating Haddocks (#4073)
- Proposal: edits to RELEASE_GUIDE.md (#4104)
- Fix unnamed instance docs issue (#4111)
- Allow fixity, kind, role declarations in REPL (#4046)
- Pin OS versions in CI, instead of using the latest (#4113)
- Fix UnusedName for multiple non-recursive let bindings (#4114)
- Use GenIdent for anonymous instances (#4096)
- Move type class instance name desugaring into type class desugaring pass (#4099)
- Display kind signatures and comments in docs (#4100)
- Remove generated names from errors about instances (#4118)
- Display inferred kind signatures in HTML docs (#4119)
- RELEASE_GUIDE.md: s/Or alternatively/Alternatively/ (#4123)
- Improve apartness checking (#4064)
- Revert "Improve apartness checking (#4064)" (#4129)
- fixup! Import CommonJS foreign modules through an ES module wrapper
- fixup! Don't optimize away dependencies of named ES exports of declarations
- Revert "Disallow CommonJS exports named `default`"
- Add tests for foreign CommonJS exports named default
- Extend support to Node.js v12.0.0 with --experimental-modules
- Filter out Node.js experimental ES modules loader warning
- Update bundler error messages
- Fix HLint warnings
- Update version to v0.15.0
