### PR TITLE
Update version to v0.15.0

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.14.2
+version:        0.15.0
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language


### PR DESCRIPTION
When I build this locally and attempt to use the package set with Spago, I get an error because the compiler versions mismatch. I could set the metadata version to v0.14.2, but that isn't actually true. AFAIK, this branch includes all the work done in `v0.14.5`, so bumping this to `v0.15.0` is more appropriate.