### PR TITLE
Add purity annotations to top-level applications only.

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -80,7 +80,7 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
   where
   -- | Adds purity annotations to top-level applications.
   annotatePure :: AST -> AST
-  annotatePure app@(AST.App _ _ _) = AST.Pure Nothing app
+  annotatePure (AST.App ss a bs) = AST.Pure Nothing (AST.App ss (annotatePure a) (annotatePure <$> bs))
   annotatePure (AST.ObjectLiteral ss props) = AST.ObjectLiteral ss (fmap annotatePure <$> props)
   annotatePure (AST.ArrayLiteral ss js) = AST.ArrayLiteral ss (annotatePure <$> js)
   annotatePure (AST.VariableIntroduction ss name (Just js)) = AST.VariableIntroduction ss name (Just (annotatePure js))

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -80,7 +80,10 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
   where
   -- | Adds purity annotations to top-level applications.
   annotatePure :: AST -> AST
-  annotatePure (AST.VariableIntroduction ss name (Just app@(AST.App _ _ _))) = AST.VariableIntroduction ss name (Just (AST.Pure Nothing app))
+  annotatePure app@(AST.App _ _ _) = AST.Pure Nothing app
+  annotatePure (AST.ObjectLiteral ss props) = AST.ObjectLiteral ss (fmap annotatePure <$> props)
+  annotatePure (AST.ArrayLiteral ss js) = AST.ArrayLiteral ss (annotatePure <$> js)
+  annotatePure (AST.VariableIntroduction ss name (Just js)) = AST.VariableIntroduction ss name (Just (annotatePure js))
   annotatePure (AST.Comment a b js) = AST.Comment a b (annotatePure js)
   annotatePure js = js
 

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -121,9 +121,8 @@ literals = mkPattern' match'
     , prettyPrintJS' js
     ]
   match (Pure _ js) = mconcat <$> sequence 
-    [ return $ emit  "/* @__PURE__ */("
+    [ return $ emit  "/* @__PURE__ */ "
     , prettyPrintJS' js 
-    , return $ emit ")"
     ]
   match (Import _ ident from) = return . emit $
     "import * as " <> ident <> " from " <> prettyPrintStringJS from

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -121,7 +121,7 @@ literals = mkPattern' match'
     , prettyPrintJS' js
     ]
   match (Pure _ js) = mconcat <$> sequence 
-    [ return $ emit  "/* @__PURE__ */ "
+    [ return $ emit  "/* #__PURE__ */ "
     , prettyPrintJS' js 
     ]
   match (Import _ ident from) = return . emit $


### PR DESCRIPTION
This adds purity annotations to top-level function applications _only_. This essentially replicates the logic purs-bundle is doing, and results in a minified esbuild bundle that is only 6% larger than purs-bundle+esbuild (on the bundle challenge). I have not verified all the cases that stick around, but I know some of it is because purs-bundle treats top-level declarations in FFI modules as pure, and will remove them, but esbuild of course won't (without the annotation). If annotations were added to FFI modules, the result would likely be smaller.

I think this is a much safer optimization, and one a feel confident about understanding and documenting.