### PR TITLE
AST and IIFE refinements

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -207,6 +207,7 @@ library
     Language.PureScript.CoreFn.Traversals
     Language.PureScript.CoreImp
     Language.PureScript.CoreImp.AST
+    Language.PureScript.CoreImp.Module
     Language.PureScript.CoreImp.Optimizer
     Language.PureScript.CoreImp.Optimizer.Blocks
     Language.PureScript.CoreImp.Optimizer.Common

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -115,13 +115,13 @@ literals = mkPattern' match'
     [ return $ emit "throw "
     , prettyPrintJS' value
     ]
-  match (Comment _ com js) = mconcat <$> sequence
+  match (Comment (SourceComments com) js) = mconcat <$> sequence
     [ return $ emit "\n"
     , mconcat <$> forM com comment
     , prettyPrintJS' js
     ]
-  match (Pure _ js) = mconcat <$> sequence 
-    [ return $ emit  "/* #__PURE__ */ "
+  match (Comment PureAnnotation js) = mconcat <$> sequence 
+    [ return $ emit "/* #__PURE__ */ "
     , prettyPrintJS' js 
     ]
   match (Import _ ident from) = return . emit $

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -20,6 +20,7 @@ import qualified Data.List.NonEmpty as NEL (toList)
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.CodeGen.JS.Common
 import Language.PureScript.CoreImp.AST
+import Language.PureScript.CoreImp.Module
 import Language.PureScript.Comments
 import Language.PureScript.Crash
 import Language.PureScript.Pretty.Common
@@ -124,9 +125,44 @@ literals = mkPattern' match'
     [ return $ emit "/* #__PURE__ */ "
     , prettyPrintJS' js 
     ]
-  match (Import _ ident from) = return . emit $
-    "import * as " <> ident <> " from " <> prettyPrintStringJS from
-  match (Export _ idents from) = mconcat <$> sequence
+  match _ = mzero
+
+comment :: (Emit gen) => Comment -> StateT PrinterState Maybe gen
+comment (LineComment com) = mconcat <$> sequence
+  [ currentIndent
+  , return $ emit "//" <> emit com <> emit "\n"
+  ]
+comment (BlockComment com) = fmap mconcat $ sequence $
+  [ currentIndent
+  , return $ emit "/**\n"
+  ] ++
+  map asLine (T.lines com) ++
+  [ currentIndent
+  , return $ emit " */\n"
+  , currentIndent
+  ]
+  where
+  asLine :: (Emit gen) => Text -> StateT PrinterState Maybe gen
+  asLine s = do
+    i <- currentIndent
+    return $ i <> emit " * " <> (emit . removeComments) s <> emit "\n"
+
+  removeComments :: Text -> Text
+  removeComments t =
+    case T.stripPrefix "*/" t of
+      Just rest -> removeComments rest
+      Nothing -> case T.uncons t of
+        Just (x, xs) -> x `T.cons` removeComments xs
+        Nothing -> ""
+
+prettyImport :: (Emit gen) => Import -> StateT PrinterState Maybe gen
+prettyImport (Import ident from) =
+  return . emit $
+    "import * as " <> ident <> " from " <> prettyPrintStringJS from <> ";"
+
+prettyExport :: (Emit gen) => Export -> StateT PrinterState Maybe gen
+prettyExport (Export idents from) =
+  mconcat <$> sequence
     [ return $ emit "export {\n"
     , withIndent $ do
         let exportsStrings = emit . exportedIdentToString from <$> idents
@@ -134,45 +170,16 @@ literals = mkPattern' match'
         return . intercalate (emit ",\n") . NEL.toList $ (indentString <>) <$> exportsStrings
     , return $ emit "\n"
     , currentIndent
-    , return . emit $ "}" <> maybe "" ((" from " <>) . prettyPrintStringJS) from
+    , return . emit $ "}" <> maybe "" ((" from " <>) . prettyPrintStringJS) from <> ";"
     ]
-    where
-    exportedIdentToString Nothing ident
-      | nameIsJsReserved ident || nameIsJsBuiltIn ident
-      = "$$" <> ident <> " as " <> ident
-    exportedIdentToString _ "$main"
-      = T.concatMap identCharToText "$main" <> " as $main"
-    exportedIdentToString _ ident
-      = T.concatMap identCharToText ident
-  match _ = mzero
-
-  comment :: (Emit gen) => Comment -> StateT PrinterState Maybe gen
-  comment (LineComment com) = mconcat <$> sequence
-    [ currentIndent
-    , return $ emit "//" <> emit com <> emit "\n"
-    ]
-  comment (BlockComment com) = fmap mconcat $ sequence $
-    [ currentIndent
-    , return $ emit "/**\n"
-    ] ++
-    map asLine (T.lines com) ++
-    [ currentIndent
-    , return $ emit " */\n"
-    , currentIndent
-    ]
-    where
-    asLine :: (Emit gen) => Text -> StateT PrinterState Maybe gen
-    asLine s = do
-      i <- currentIndent
-      return $ i <> emit " * " <> (emit . removeComments) s <> emit "\n"
-
-    removeComments :: Text -> Text
-    removeComments t =
-      case T.stripPrefix "*/" t of
-        Just rest -> removeComments rest
-        Nothing -> case T.uncons t of
-          Just (x, xs) -> x `T.cons` removeComments xs
-          Nothing -> ""
+  where
+  exportedIdentToString Nothing ident
+    | nameIsJsReserved ident || nameIsJsBuiltIn ident
+    = "$$" <> ident <> " as " <> ident
+  exportedIdentToString _ "$main"
+    = T.concatMap identCharToText "$main" <> " as $main"
+  exportedIdentToString _ ident
+    = T.concatMap identCharToText ident
 
 accessor :: Pattern PrinterState AST (Text, AST)
 accessor = mkPattern match
@@ -242,14 +249,22 @@ prettyStatements sts = do
   indentString <- currentIndent
   return $ intercalate (emit "\n") $ map ((<> emit ";") . (indentString <>)) jss
 
+prettyModule :: (Emit gen) => Module -> StateT PrinterState Maybe gen
+prettyModule Module{..} = do
+  header <- mconcat <$> traverse comment modHeader
+  imps <- traverse prettyImport modImports
+  body <- prettyStatements modBody
+  exps <- traverse prettyExport modExports
+  pure $ header <> intercalate (emit "\n") (imps ++ body : exps)
+
 -- | Generate a pretty-printed string representing a collection of JavaScript expressions at the same indentation level
-prettyPrintJSWithSourceMaps :: [AST] -> (Text, [SMap])
+prettyPrintJSWithSourceMaps :: Module -> (Text, [SMap])
 prettyPrintJSWithSourceMaps js =
-  let StrPos (_, s, mp) = (fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyStatements) js
+  let StrPos (_, s, mp) = (fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyModule) js
   in (s, mp)
 
-prettyPrintJS :: [AST] -> Text
-prettyPrintJS = maybe (internalError "Incomplete pattern") runPlainString . flip evalStateT (PrinterState 0) . prettyStatements
+prettyPrintJS :: Module -> Text
+prettyPrintJS = maybe (internalError "Incomplete pattern") runPlainString . flip evalStateT (PrinterState 0) . prettyModule
 
 -- | Generate an indented, pretty-printed string representing a JavaScript expression
 prettyPrintJS' :: (Emit gen) => AST -> StateT PrinterState Maybe gen

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -6,7 +6,6 @@ import Prelude.Compat
 import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.Text (Text)
-import qualified Data.List.NonEmpty as NEL (NonEmpty)
 
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.Comments
@@ -100,10 +99,6 @@ data AST
   -- ^ instanceof check
   | Comment CIComments AST
   -- ^ Commented JavaScript
-  | Import (Maybe SourceSpan) Text PSString
-  -- ^ Imported identifier and path to its module
-  | Export (Maybe SourceSpan) (NEL.NonEmpty Text) (Maybe PSString)
-  -- ^ Exported identifiers and optional path to their module (for re-exports)
   deriving (Show, Eq)
 
 withSourceSpan :: SourceSpan -> AST -> AST
@@ -135,8 +130,6 @@ withSourceSpan withSpan = go where
   go (Throw _ js) = Throw ss js
   go (InstanceOf _ j1 j2) = InstanceOf ss j1 j2
   go c@Comment{} = c
-  go (Import _ ident from) = Import ss ident from
-  go (Export _ idents from) = Export ss idents from
 
 getSourceSpan :: AST -> Maybe SourceSpan
 getSourceSpan = go where
@@ -164,8 +157,6 @@ getSourceSpan = go where
   go (Throw ss _) = ss
   go (InstanceOf ss _ _) = ss
   go (Comment _ _) = Nothing
-  go (Import ss _ _) = ss
-  go (Export ss _ _) = ss
 
 everywhere :: (AST -> AST) -> AST -> AST
 everywhere f = go where

--- a/src/Language/PureScript/CoreImp/Module.hs
+++ b/src/Language/PureScript/CoreImp/Module.hs
@@ -1,0 +1,19 @@
+module Language.PureScript.CoreImp.Module where
+
+import Protolude
+import qualified Data.List.NonEmpty as NEL (NonEmpty)
+
+import Language.PureScript.Comments
+import Language.PureScript.CoreImp.AST
+import Language.PureScript.PSString (PSString)
+
+data Module = Module
+  { modHeader :: [Comment]
+  , modImports :: [Import]
+  , modBody :: [AST]
+  , modExports :: [Export]
+  }
+
+data Import = Import Text PSString
+
+data Export = Export (NEL.NonEmpty Text) (Maybe PSString)

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -121,7 +121,7 @@ tco = flip evalState 0 . everywhereTopDownM convert where
       | otherwise = empty
     allInTailPosition (Assignment _ _ js1)
       = guard (countSelfReferences js1 == 0) $> S.empty
-    allInTailPosition (Comment _ _ js1)
+    allInTailPosition (Comment _ js1)
       = allInTailPosition js1
     allInTailPosition _
       = empty

--- a/tests/purs/optimize/2866.out.js
+++ b/tests/purs/optimize/2866.out.js
@@ -1,4 +1,3 @@
-
 // Canonical test for #2866. This doesn't need to test whether `apply`s
 // defined from modules other than `Data.Function` are incorrectly
 // optimized since the rest of the test suite seemingly catches it.


### PR DESCRIPTION
**Description of the change**

Hello the working group!

After reviewing the ES modules PR I had two nagging concerns that I wanted to work on; this PR addresses them.

I wasn't crazy about how the number of constructors in the CoreImp AST was growing. Adding complexity there makes writing CoreImp optimizations more difficult. Also, the new constructors were just sort of an awkward fit in my opinion; import and export statements can't mix with the rest of a module's AST, and the `Pure` constructor was just a comment with some special printing behavior.

To address this, the first commit in this PR merges the `Comment` and `Pure` constructors (and also removes a never-used `SourceSpan` parameter from both). The second commit replaces the `[AST]` type in the return value of `moduleToJs` with a new `CoreImp.Module` type that holds separate fields for header comments, imports, the module body, and exports, allowing the `Import` and `Export` constructors to be removed from the main CoreImp `AST` type.

My other concern was the fairly liberal use of IIFEs at the top level to enable dead code elimination in external bundlers, particularly for object and array literals. Especially given that class instances take the form of top-level object literals, I wanted to protect them from any clutter that isn't absolutely necessary. The third commit here is a reimplementation of the pure-annotating function that tries a little harder not to create IIFEs. I ran the bundler benchmark from purescript-halogen-template on this new PR, and the revised implementation shaves another 2 KB off of the minified output of each bundler, representing more than half of the IIFEs introduced by the original implementation. (Note that in a few cases, this new implementation leads to more pure-annotation comments than the old one; for example:
```js
var isJust = /* #__PURE__ */ maybe(false)(/* #__PURE__ */ Data_Function["const"](true));
```
But those disappear during minification, unlike IIFEs, or can be removed with simple global search-and-replace tools, also unlike IIFEs. Also, yes, one of the improvements here is that an IIFE isn't necessary for `Data_Function["const"]`, because `Data_Function` will be an ES module object, and the bundlers tested don't expect those to have effectful getters.)

<details>
<summary>Full results from bundle.sh</summary>
(<code>generous-iifes</code> is the original PR; <code>stingy-iifes</code> is this PR.)
<pre>
$ tree -s bundles
bundles
├── [         66]  esbuild
│   ├── [        112]  generous-iifes
│   │   ├── [     203649]  index.js
│   │   ├── [      30486]  index.js.gz
│   │   ├── [      84539]  index.minified.js
│   │   └── [      18677]  index.minified.js.gz
│   ├── [        112]  stingy-iifes
│   │   ├── [     197813]  index.js
│   │   ├── [      30318]  index.js.gz
│   │   ├── [      82242]  index.minified.js
│   │   └── [      18494]  index.minified.js.gz
│   └── [        112]  v0.14.5
│       ├── [     259386]  index.js
│       ├── [      35835]  index.js.gz
│       ├── [     112911]  index.minified.js
│       └── [      24801]  index.minified.js.gz
├── [         52]  parcel
│   ├── [        168]  generous-iifes
│   │   ├── [    2116771]  index.13db5cae.js
│   │   ├── [     232545]  index.13db5cae.js.gz
│   │   ├── [      80107]  index.8524bd67.js
│   │   ├── [      16962]  index.8524bd67.js.gz
│   │   └── [        166]  index.html
│   └── [        168]  stingy-iifes
│       ├── [    2010525]  index.5a8573a1.js
│       ├── [     230689]  index.5a8573a1.js.gz
│       ├── [      77706]  index.cfeb9ae0.js
│       ├── [      16703]  index.cfeb9ae0.js.gz
│       └── [        166]  index.html
├── [         66]  purs
│   ├── [        172]  index.cjs.html
│   ├── [     280474]  index.js
│   └── [      39881]  index.js.gz
└── [         52]  webpack
    ├── [        112]  generous-iifes
    │   ├── [    2997585]  index.js
    │   ├── [     257231]  index.js.gz
    │   ├── [      78385]  index.minified.js
    │   └── [      16675]  index.minified.js.gz
    └── [        112]  stingy-iifes
        ├── [    2879227]  index.js
        ├── [     255871]  index.js.gz
        ├── [      75664]  index.minified.js
        └── [      16394]  index.minified.js.gz
</pre>
</details>

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
